### PR TITLE
Make some updates for GOV.UK Frontend v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ This Python package includes classes and modules to make it easier to use the
 
 > **NOTE**: This repository is maintained by GDS developers, but **not** the
 > GOV.UK Design System team. If you have questions or need support raise an
-> issue against this repo [here](https://github.com/alphagov/govuk-frontend-jinja/issues).
+> issue against this repo [here](https://github.com/Crown-Commercial-Service//govuk-frontend-jinja/issues).
 
 ## Installing
 
 ```shell
-pip install git+https://github.com/alphagov/govuk-frontend-jinja.git
+pip install git+https://github.com/Crown-Commercial-Service//govuk-frontend-jinja.git
 ```
 
 ## Using with Flask

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,11 @@ setuptools.setup(
     description="Tools to use the GOV.UK Design System with Jinja-powered Python apps",
     packages=setuptools.find_packages(),
     install_requires=[
-        "jinja2",
+        "jinja2<3.0",
+        "markupsafe<2.0"
     ],
     extras_require={
-        "Flask": ["Flask"],
+        "Flask": ["Flask>=1.0,<2.1"],
         "dev": [
             "pytest",
             "pytest-flakes",

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -101,3 +101,27 @@ class TestStrictEquality:
         assert template.render(var=True) == "true if true"
         assert template.render(var=False) == ""
         assert template.render(var=1) == ""
+
+
+class TestStrictInequality():
+    def test_jinja_raises_syntax_error_for_strict_inequality_operator(self, env):
+        with pytest.raises(
+            jinja2.exceptions.TemplateSyntaxError, match="unexpected '='"
+        ):
+            env.from_string("{% if 1 !== 1 %}always false{% endif %}")
+
+    def test_njk_has_strict_inequality_operator(self, env):
+        template = njk_template_from_string(
+            env, "{% if 1 !== 2 %}always true{% endif %}"
+        )
+
+        assert template.render() == "always true"
+
+    def test_strict_inequality_operator(self, env):
+        template = njk_template_from_string(
+            env, "{% if var !== undefined %}true if not undefined{% endif %}"
+        )
+
+        assert template.render() == ""
+        assert template.render(var=False) == "true if not undefined"
+        assert template.render(var=1) == "true if not undefined"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -22,6 +22,24 @@ def test_replaces_items_getattr_with_getitem():
     )
 
 
+def test_replaces_values_getattr_with_getitem():
+    assert (
+        njk_to_j2 (
+"""
+{% for value in params.values %}
+  value
+{% endfor %}
+"""
+        )
+        ==
+"""
+{% for value in params.values__njk %}
+  value
+{% endfor %}
+"""
+    )
+
+
 def test_replaces_add_loop_index_with_concatenate():
     assert (
         njk_to_j2(

--- a/tox.ini
+++ b/tox.ini
@@ -6,3 +6,6 @@ extras =
 commands =
     sh scripts/get-govuk-frontend.sh
     pytest {posargs}
+allowlist_externals=
+    sh
+    pytest


### PR DESCRIPTION
There were some compatibility issues with the latest GOV.UK Frontend.

These included:
- Strict inequality, i.e. `!==`
- `.values` calling the inbuilt dict method

I’ve made the updates so these features now work. I’ve not added tests for GOV.UK Frontend v4 as I found this to be too difficult. Plus our aim is to move away from this eventually and use real Jinja macros.