### PR TITLE
Release 0.6.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2023-09-06 version 0.6.0-alpha
+
+### Features
+
+* Make compatible with GOV.UK Frontend v4 ([#69](https://github.com/Crown-Commercial-Service/govuk-frontend-jinja/pull/69))
+
 ## 2020-12-22 version 0.5.8-alpha
 
 ### Bugfixes

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="govuk-frontend-jinja",
-    version="0.5.8-alpha",
+    version="0.6.0-alpha",
     author="Laurence de Bruxelles",
     author_email="author@example.com",
     description="Tools to use the GOV.UK Design System with Jinja-powered Python apps",


### PR DESCRIPTION
### Features

* Make compatible with GOV.UK Frontend v4 ([#69](https://github.com/Crown-Commercial-Service/govuk-frontend-jinja/pull/69))